### PR TITLE
Fix supportedLocales property being ignored during golden test execution

### DIFF
--- a/lib/src/create_golden_test.dart
+++ b/lib/src/create_golden_test.dart
@@ -40,6 +40,7 @@ void createGoldenTest(
       child: MaterialApp(
         locale: properties.locale,
         localizationsDelegates: properties.localizationsDelegates,
+        supportedLocales: properties.supportedLocales,
         theme: properties.theme,
         home: Scaffold(
           body: Builder(

--- a/lib/src/widgetbook_golden_tests_properties.dart
+++ b/lib/src/widgetbook_golden_tests_properties.dart
@@ -12,7 +12,7 @@ class WidgetbookGoldenTestsProperties {
   final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
 
   /// Supported locales that the app supports.
-  final Iterable<Locale>? supportedLocales;
+  final Iterable<Locale> supportedLocales;
 
   /// Tag used to identify tests that should be skipped during golden testing.
   final String skipTag;
@@ -30,7 +30,7 @@ class WidgetbookGoldenTestsProperties {
     this.theme,
     this.locale,
     this.localizationsDelegates,
-    this.supportedLocales,
+    this.supportedLocales = const [Locale('en', 'US')],
     this.skipTag = "[skip-golden]",
     this.errorImageUrl = "error-network-image",
     this.loadingImageUrl = "loading-network-image",


### PR DESCRIPTION
Due to an oversight, the supportedLocales from WidgetbookGoldenTestsProperties was not being passed down to the MaterialApp created for the golden tests. It is now being passed and using the same default value of Locale('en', 'US').