### PR TITLE
fix: Golden test run indefinitely when the expected image is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## Unreleased
-- Fix theme extensions not properly loading. (thanks @Gustl22)
-- Add parameter based skip in WidgetbookGoldenTestBuilder.
+### Added
+- Parameter based skip in WidgetbookGoldenTestBuilder.
   * This will deprecate the `skipTag` property in WidgetbookGoldenTestsProperties.
 - Handle golden tests with interaction as separate test cases.
+
+### Fixed
+- Theme extensions not properly loading. (thanks @Gustl22)
+- Golden test run indefinitely when the expected image is not found.
+
+### Deprecated
 - Deprecate `locale`, `localizationsDelegates` and `supportedLocales` properties in WidgetbookGoldenTestsProperties.
   * These properties will be handled by the `LocalizationAddon`.
 

--- a/lib/src/create_golden_test.dart
+++ b/lib/src/create_golden_test.dart
@@ -99,7 +99,7 @@ void testWidgetsGolden(
           stack: stack,
           context: ErrorDescription(error.toString()),
         );
-        handleError(details, properties, previousOnError);
+        handleError(details, properties, null);
       },
     );
   }, skip: skip);
@@ -143,7 +143,9 @@ void handleError(
 
   if (properties.onTestError != null) {
     properties.onTestError!(details, previousOnError);
+  } else if (previousOnError != null) {
+    previousOnError(details);
   } else {
-    previousOnError?.call(details);
+    throw details.exception;
   }
 }

--- a/test/unit/create_golden_test_test.dart
+++ b/test/unit/create_golden_test_test.dart
@@ -53,5 +53,20 @@ void main() {
       FlutterError.onError = previousOnError;
       expect(calledCustomPreviousOnError, true);
     });
+
+    testWidgets('throws when no previousOnError is provided', (tester) async {
+      expect(
+        () => handleError(
+          FlutterErrorDetails(
+            exception: Exception("test"),
+            stack: StackTrace.current,
+            context: ErrorDescription("test"),
+          ),
+          WidgetbookGoldenTestsProperties(),
+          null,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
The runZonedGuarded was absorbing the exceptions thrown by expectLater and it would await forever. To fix this, modified handleError to just throw the exception in the details if previousOnError is null and just pass it as null on purpose to the onError argument of runZonedGuarded