### PR TITLE
feat: add configurable precacheImagesTimeout to WidgetbookGoldenTestsProperties

### DIFF
--- a/apps/widgetbook_samples/lib/cases/popup_menu_button.dart
+++ b/apps/widgetbook_samples/lib/cases/popup_menu_button.dart
@@ -8,18 +8,16 @@ Widget buildPopupMenuButtonUseCase(BuildContext context) {
     goldenActions: [
       GoldenPlayAction(
         name: "clicked",
-        callback:
-            (tester, find) async => tester.tap(find.byType(PopupMenuButton)),
+        callback: (tester, find) async =>
+            tester.tap(find.byType(PopupMenuButton)),
         goldenFinder: (find) => find.byType(MaterialApp).first,
       ),
     ],
-    builder:
-        (context) => PopupMenuButton(
-          itemBuilder:
-              (context) => [
-                PopupMenuItem(child: Text("First option")),
-                PopupMenuItem(child: Icon(Icons.share)),
-              ],
-        ),
+    builder: (context) => PopupMenuButton(
+      itemBuilder: (context) => [
+        PopupMenuItem(child: Text("First option")),
+        PopupMenuItem(child: Icon(Icons.share)),
+      ],
+    ),
   );
 }

--- a/apps/widgetbook_samples/lib/cases/sized_box_cases.dart
+++ b/apps/widgetbook_samples/lib/cases/sized_box_cases.dart
@@ -14,12 +14,8 @@ Widget buildOrangeSizedBoxUseCase(BuildContext context) {
     addons: [
       ViewportAddon([LinuxViewports.desktop]),
     ],
-    builder:
-        (context) => SizedBox(
-          height: 20,
-          width: 20,
-          child: Container(color: Colors.orange),
-        ),
+    builder: (context) =>
+        SizedBox(height: 20, width: 20, child: Container(color: Colors.orange)),
   );
 }
 
@@ -27,12 +23,11 @@ Widget buildOrangeSizedBoxUseCase(BuildContext context) {
 Widget buildGreenSizedBoxUseCase(BuildContext context) {
   return WidgetbookGoldenTestBuilder(
     skip: true,
-    builder:
-        (context) => SizedBox(
-          height: 200,
-          width: 200,
-          child: Container(color: Colors.green),
-        ),
+    builder: (context) => SizedBox(
+      height: 200,
+      width: 200,
+      child: Container(color: Colors.green),
+    ),
   );
 }
 

--- a/apps/widgetbook_samples/lib/cases/svg_picture.dart
+++ b/apps/widgetbook_samples/lib/cases/svg_picture.dart
@@ -9,9 +9,8 @@ Widget buildNetworkSvgUseCase(BuildContext context) {
     "https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/android.svg",
     height: 600,
     width: 400,
-    errorBuilder:
-        (context, _, trace) =>
-            Container(height: 200, width: 200, color: Colors.red),
+    errorBuilder: (context, _, trace) =>
+        Container(height: 200, width: 200, color: Colors.red),
   );
 }
 
@@ -21,9 +20,8 @@ Widget buildErrorNetworkSvgUseCase(BuildContext context) {
     WidgetbookGoldenTestsProperties.defaultErrorImageUrl,
     height: 600,
     width: 400,
-    errorBuilder:
-        (context, _, trace) =>
-            Container(height: 200, width: 200, color: Colors.red),
+    errorBuilder: (context, _, trace) =>
+        Container(height: 200, width: 200, color: Colors.red),
   );
 }
 
@@ -34,8 +32,7 @@ Widget buildLoadingNetworkSvgUseCase(BuildContext context) {
     height: 600,
     width: 400,
     placeholderBuilder: (context) => Text("Loading..."),
-    errorBuilder:
-        (context, _, trace) =>
-            Container(height: 200, width: 200, color: Colors.red),
+    errorBuilder: (context, _, trace) =>
+        Container(height: 200, width: 200, color: Colors.red),
   );
 }

--- a/packages/widgetbook_golden_test_core/CHANGELOG.md
+++ b/packages/widgetbook_golden_test_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Added
+- Added [precacheImagesTimeout] property to [WidgetbookGoldenTestsProperties] to configure the timeout for precaching images.
+
+### Fixed
+
 ## 0.4.0
 Initial release.
 

--- a/packages/widgetbook_golden_test_core/lib/src/widget_tester_extension.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widget_tester_extension.dart
@@ -57,7 +57,7 @@ extension WidgetTesterExtension on WidgetTester {
       // Use the custom precacheImage if provided, otherwise fallback to default
       var precacheFunction = customPrecacheImage ?? precacheImage;
       await precacheFunction(provider, element).timeout(
-        Duration(seconds: 10),
+        properties.precacheImagesTimeout,
         onTimeout: () {
           // If timed out, perhaps there was some kind of unsupported Image Provider.
           return;

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
@@ -49,6 +49,9 @@ class WidgetbookGoldenTestsProperties {
   /// URL of the image to display while a network request is in progress.
   final String loadingImageUrl;
 
+  /// Duration to wait for precaching images. Default value is 10 seconds.
+  final Duration precacheImagesTimeout;
+
   /// Name of the group of tests being run.
   final String testGroupName;
 
@@ -76,6 +79,7 @@ class WidgetbookGoldenTestsProperties {
   /// * [skipTag] – Tag used to skip tests when present (defaults to `"[skip-golden]"`).
   /// * [errorImageUrl] – Placeholder URL for failed network images (defaults to `'error-network-image'`).
   /// * [loadingImageUrl] – Placeholder URL while loading network images (defaults to `'loading-network-image'`).
+  /// * [precacheImagesTimeout] – Duration to wait for precaching images (defaults to `10 seconds`).
   /// * [testGroupName] – Name of the golden test group (used for grouping tests) (defaults to `'Widgetbook golden tests'`).
   /// * [onTestError] - Function to be called when there is an error during the golden tests.
   /// * [networkImageResolver] - Custom function that resolves images from a given URI.
@@ -102,6 +106,7 @@ class WidgetbookGoldenTestsProperties {
     this.skipTag = defaultSkipTag,
     this.errorImageUrl = defaultErrorImageUrl,
     this.loadingImageUrl = defaultLoadingImageUrl,
+    this.precacheImagesTimeout = const Duration(seconds: 10),
     this.testGroupName = "Widgetbook golden tests",
     this.onTestError,
     NetworkImageResolver? networkImageResolver,
@@ -117,6 +122,7 @@ class WidgetbookGoldenTestsProperties {
     String? skipTag,
     String? errorImageUrl,
     String? loadingImageUrl,
+    Duration? precacheImagesTimeout,
     String? testGroupName,
     Function(FlutterErrorDetails, Function(FlutterErrorDetails)?)? onTestError,
     NetworkImageResolver? networkImageResolver,
@@ -137,6 +143,8 @@ class WidgetbookGoldenTestsProperties {
       skipTag: skipTag ?? this.skipTag,
       errorImageUrl: errorImageUrl ?? this.errorImageUrl,
       loadingImageUrl: loadingImageUrl ?? this.loadingImageUrl,
+      precacheImagesTimeout:
+          precacheImagesTimeout ?? this.precacheImagesTimeout,
       testGroupName: testGroupName ?? this.testGroupName,
       onTestError: onTestError ?? this.onTestError,
       networkImageResolver: networkImageResolver ?? this.networkImageResolver,

--- a/packages/widgetbook_golden_test_core/test/unit/widget_tester_extension_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widget_tester_extension_test.dart
@@ -73,7 +73,7 @@ void main() {
         expect(precacheCalls, equals(3)); // Only three should be precached
       });
 
-      testWidgets('continues normally on timeout of 10 seconds', (
+      testWidgets('continues normally on timeout using default 10 seconds', (
         tester,
       ) async {
         var completed = false;
@@ -95,6 +95,109 @@ void main() {
             .then((_) => completed = true);
         await tester.pump(const Duration(seconds: 11));
         expect(completed, true);
+      });
+
+      testWidgets('uses configurable precacheImagesTimeout', (tester) async {
+        var completed = false;
+        var magentaPixel = base64Decode(
+          """iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVR4AQEEAPv/AP8A/wQAAf/2bp8NAAAAAElFTkSuQmCC""",
+        );
+
+        // Use a short timeout of 500ms to verify the configurable value is used
+        final properties = WidgetbookGoldenTestsProperties(
+          precacheImagesTimeout: const Duration(milliseconds: 500),
+        );
+
+        Future<void> fakePrecache(
+          ImageProvider provider, [
+          BuildContext? context,
+        ]) async {
+          await Completer().future;
+          return;
+        }
+
+        await tester.pumpWidget(Column(children: [Image.memory(magentaPixel)]));
+        tester
+            .precacheImages(properties, customPrecacheImage: fakePrecache)
+            .then((_) => completed = true);
+        // Wait longer than 500ms but less than the default 10s
+        await tester.pump(const Duration(milliseconds: 600));
+        expect(completed, isTrue);
+      });
+
+      testWidgets('waits full configurable timeout before timing out', (
+        tester,
+      ) async {
+        var completed = false;
+        var magentaPixel = base64Decode(
+          """iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVR4AQEEAPv/AP8A/wQAAf/2bp8NAAAAAElFTkSuQmCC""",
+        );
+
+        // Use a longer timeout of 5 seconds to verify it waits the full duration
+        final properties = WidgetbookGoldenTestsProperties(
+          precacheImagesTimeout: const Duration(seconds: 5),
+        );
+
+        Future<void> fakePrecache(
+          ImageProvider provider, [
+          BuildContext? context,
+        ]) async {
+          await Completer().future;
+          return;
+        }
+
+        await tester.pumpWidget(Column(children: [Image.memory(magentaPixel)]));
+        tester
+            .precacheImages(properties, customPrecacheImage: fakePrecache)
+            .then((_) => completed = true);
+        // Wait 4 seconds - should NOT be complete yet (timeout is 5s)
+        await tester.pump(const Duration(seconds: 4));
+        expect(completed, isFalse);
+
+        // Pump past the timeout - should now be complete
+        await tester.pump(const Duration(milliseconds: 1001));
+        expect(completed, isTrue);
+      });
+
+      testWidgets('handles zero duration timeout', (tester) async {
+        var completed = false;
+        var magentaPixel = base64Decode(
+          """iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVR4AQEEAPv/AP8A/wQAAf/2bp8NAAAAAElFTkSuQmCC""",
+        );
+
+        final properties = WidgetbookGoldenTestsProperties(
+          precacheImagesTimeout: Duration.zero,
+        );
+
+        Future<void> fakePrecache(
+          ImageProvider provider, [
+          BuildContext? context,
+        ]) async {
+          await Completer().future;
+          return;
+        }
+
+        await tester.pumpWidget(Column(children: [Image.memory(magentaPixel)]));
+        // With zero timeout, the future should complete immediately (or very quickly)
+        tester
+            .precacheImages(properties, customPrecacheImage: fakePrecache)
+            .then((_) => completed = true);
+        await tester.pump(Duration.zero);
+        expect(completed, isTrue);
+      });
+
+      testWidgets('handles empty image list gracefully', (tester) async {
+        final properties = WidgetbookGoldenTestsProperties();
+
+        // No Image widgets in the tree - should not throw
+        await tester.pumpWidget(
+          MaterialApp(home: const Text("No images here")),
+        );
+
+        expect(
+          () => tester.precacheImages(properties),
+          returnsNormally,
+        );
       });
     });
   });

--- a/packages/widgetbook_golden_test_core/test/unit/widget_tester_extension_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widget_tester_extension_test.dart
@@ -194,10 +194,7 @@ void main() {
           MaterialApp(home: const Text("No images here")),
         );
 
-        expect(
-          () => tester.precacheImages(properties),
-          returnsNormally,
-        );
+        expect(() => tester.precacheImages(properties), returnsNormally);
       });
     });
   });

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_tests_properties_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_tests_properties_test.dart
@@ -97,4 +97,40 @@ void main() {
     expect(copied.loadingImageUrl, "custom-loading-image");
     expect(copied.testGroupName, "Custom golden tests");
   });
+
+  group("precacheImagesTimeout", () {
+    test("defaults to 10 seconds", () {
+      final properties = WidgetbookGoldenTestsProperties();
+
+      expect(properties.precacheImagesTimeout, const Duration(seconds: 10));
+    });
+
+    test("can be set with a custom duration", () {
+      final properties = WidgetbookGoldenTestsProperties(
+        precacheImagesTimeout: const Duration(milliseconds: 500),
+      );
+
+      expect(properties.precacheImagesTimeout, const Duration(milliseconds: 500));
+    });
+
+    test("copyWith preserves precacheImagesTimeout when not overridden", () {
+      final original = WidgetbookGoldenTestsProperties(
+        precacheImagesTimeout: const Duration(seconds: 30),
+      );
+      final copied = original.copyWith(testGroupName: "New name");
+
+      expect(copied.precacheImagesTimeout, const Duration(seconds: 30));
+    });
+
+    test("copyWith updates precacheImagesTimeout when provided", () {
+      final original = WidgetbookGoldenTestsProperties(
+        precacheImagesTimeout: const Duration(seconds: 10),
+      );
+      final copied = original.copyWith(
+        precacheImagesTimeout: const Duration(minutes: 1),
+      );
+
+      expect(copied.precacheImagesTimeout, const Duration(minutes: 1));
+    });
+  });
 }

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_tests_properties_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_tests_properties_test.dart
@@ -110,7 +110,10 @@ void main() {
         precacheImagesTimeout: const Duration(milliseconds: 500),
       );
 
-      expect(properties.precacheImagesTimeout, const Duration(milliseconds: 500));
+      expect(
+        properties.precacheImagesTimeout,
+        const Duration(milliseconds: 500),
+      );
     });
 
     test("copyWith preserves precacheImagesTimeout when not overridden", () {


### PR DESCRIPTION
## Summary

- Adds a new `precacheImagesTimeout` property to `WidgetbookGoldenTestsProperties`, allowing users to configure the timeout duration for image precaching instead of being locked into a hardcoded 10-second default.
- Updates `WidgetTesterExtension.precacheImages()` to use the configurable timeout from properties rather than a hard-coded `Duration(seconds: 10)`.

## Changes

### Added

- **`precacheImagesTimeout`** property on `WidgetbookGoldenTestsProperties` (defaults to `Duration(seconds: 10)`).
- Unit tests for `WidgetbookGoldenTestsProperties`:
  - Default value is 10 seconds.
  - Custom duration can be set.
  - `copyWith` preserves the value when not overridden.
  - `copyWith` updates the value when provided.
- Integration/unit tests for `WidgetTesterExtension.precacheImages()`:
  - Uses configurable timeout (verified with a 500ms timeout).
  - Waits full configurable duration before timing out (verified with a 5s timeout).
  - Handles zero-duration timeout gracefully.
  - Handles empty image list without throwing.

### Changed

- `WidgetTesterExtension.precacheImages()` now reads the timeout from `properties.precacheImagesTimeout` instead of using a hard-coded value.