### PR TITLE
feat: add tag-based test grouping support with customizable configuration per golden test

### DIFF
--- a/packages/widgetbook_golden_test/dart_test.yaml
+++ b/packages/widgetbook_golden_test/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  golden:

--- a/packages/widgetbook_golden_test/lib/src/widgetbook_golden_flutter_test_renderer.dart
+++ b/packages/widgetbook_golden_test/lib/src/widgetbook_golden_flutter_test_renderer.dart
@@ -69,25 +69,33 @@ class WidgetbookGoldenFlutterTestRenderer implements WidgetbookGoldenRenderer {
     required Future<void> Function(WidgetTester tester, Widget widgetToTest)
     testBody,
   }) {
-    testWidgets(testName, (widgetTester) async {
-      await goldenTestZoneRunner(
-        testBody: () async {
-          final widget = MockedWidgetbookCase(
-            properties: properties,
-            builderAddons: goldenTestBuilder?.addons,
-            useCase: useCase,
-            constraints: goldenTestBuilder?.constraints,
-          );
-          await widgetTester.pumpWidgetbookCase(widget, properties);
-          final state = widgetTester.state<MockedWidgetbookCaseState>(
-            find.byType(MockedWidgetbookCase),
-          );
-          var widgetToTest = state.widgetToTest!;
-
-          await testBody(widgetTester, widgetToTest);
-        },
+    testWidgets(
+      testName,
+      tags: WidgetbookGoldenRenderer.resolveTags(
+        goldenTestBuilder: goldenTestBuilder,
         properties: properties,
-      );
-    }, skip: skip);
+      ),
+      (widgetTester) async {
+        await goldenTestZoneRunner(
+          testBody: () async {
+            final widget = MockedWidgetbookCase(
+              properties: properties,
+              builderAddons: goldenTestBuilder?.addons,
+              useCase: useCase,
+              constraints: goldenTestBuilder?.constraints,
+            );
+            await widgetTester.pumpWidgetbookCase(widget, properties);
+            final state = widgetTester.state<MockedWidgetbookCaseState>(
+              find.byType(MockedWidgetbookCase),
+            );
+            var widgetToTest = state.widgetToTest!;
+
+            await testBody(widgetTester, widgetToTest);
+          },
+          properties: properties,
+        );
+      },
+      skip: skip,
+    );
   }
 }

--- a/packages/widgetbook_golden_test_alchemist/dart_test.yaml
+++ b/packages/widgetbook_golden_test_alchemist/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  golden:

--- a/packages/widgetbook_golden_test_alchemist/lib/src/widgetbook_golden_alchemist_renderer.dart
+++ b/packages/widgetbook_golden_test_alchemist/lib/src/widgetbook_golden_alchemist_renderer.dart
@@ -21,6 +21,10 @@ class WidgetbookGoldenAlchemistRenderer implements WidgetbookGoldenRenderer {
       useCase.name,
       fileName: "$goldenPath/${useCase.name}",
       skip: skip,
+      tags: WidgetbookGoldenRenderer.resolveTags(
+        goldenTestBuilder: goldenTestBuilder,
+        properties: properties,
+      ),
       pumpWidget: (tester, widget) async {
         return goldenTestZoneRunner(
           testBody: () async {
@@ -57,6 +61,10 @@ class WidgetbookGoldenAlchemistRenderer implements WidgetbookGoldenRenderer {
       "${useCase.name} - ${action.name}",
       fileName: "$goldenPath/${useCase.name} - ${action.name}",
       skip: skip,
+      tags: WidgetbookGoldenRenderer.resolveTags(
+        goldenTestBuilder: goldenTestBuilder,
+        properties: properties,
+      ),
       pumpWidget: (tester, widget) async {
         return goldenTestZoneRunner(
           testBody: () async {

--- a/packages/widgetbook_golden_test_core/CHANGELOG.md
+++ b/packages/widgetbook_golden_test_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Added [precacheImagesTimeout] property to [WidgetbookGoldenTestsProperties] to configure the timeout for precaching images.
+- Added [tags] property to [WidgetbookGoldenTestsProperties] to configure the tags for the golden tests. Also added a [tags] property to [WidgetbookGoldenTestBuilder] to configure the tags per use-case.
 
 ### Fixed
 

--- a/packages/widgetbook_golden_test_core/dart_test.yaml
+++ b/packages/widgetbook_golden_test_core/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  golden:

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_builder.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_builder.dart
@@ -44,6 +44,11 @@ class WidgetbookGoldenTestBuilder extends StatelessWidget {
   /// Optional flag to skip the golden test.
   final bool skip;
 
+  /// Optional list of tags to be applied to the golden test.
+  /// When null, falls back to the tags from [WidgetbookGoldenTestsProperties].
+  /// Set to an empty list to explicitly clear all tags.
+  final List<String>? tags;
+
   /// Creates a [WidgetbookGoldenTestBuilder].
   ///
   /// [addons] is an optional list of widgetbook addons to be applied to the golden snapshots by using their default values.
@@ -53,6 +58,7 @@ class WidgetbookGoldenTestBuilder extends StatelessWidget {
   /// [constraints] is an optional BoxConstraints to be applied to the widget to be tested.
   /// [goldenActions] is an optional list of actions to execute during the test.
   /// [skip] is an optional flag to skip the golden test.
+  /// [tags] is an optional list of tags for this golden test. When null, falls back to properties.tags. Set to empty list to clear all tags.
   const WidgetbookGoldenTestBuilder({
     super.key,
     this.addons,
@@ -62,6 +68,7 @@ class WidgetbookGoldenTestBuilder extends StatelessWidget {
     this.constraints,
     this.goldenActions,
     this.skip = false,
+    this.tags,
   }) : assert(
          child != null || builder != null,
          'child or builder must be provided',

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_renderer.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_renderer.dart
@@ -6,6 +6,17 @@ import 'package:widgetbook_golden_test_core/widgetbook_golden_test_core.dart';
 /// Implementations of this interface define how to execute and verify
 /// golden tests for Widgetbook use cases.
 abstract class WidgetbookGoldenRenderer {
+  /// Resolves the tags for a golden test.
+  ///
+  /// If [goldenTestBuilder] provides tags (even an empty list), those are used.
+  /// Otherwise, falls back to [properties.tags].
+  static List<String> resolveTags({
+    required WidgetbookGoldenTestBuilder? goldenTestBuilder,
+    required WidgetbookGoldenTestsProperties properties,
+  }) {
+    return goldenTestBuilder?.tags ?? properties.tags;
+  }
+
   /// Renders a simple golden test for a [useCase].
   void renderSimpleGoldenTest({
     required WidgetbookUseCase useCase,

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
@@ -24,6 +24,9 @@ class WidgetbookGoldenTestsProperties {
   /// The strategy to merge addons.
   final AddonsMergeStrategy addonsMergeStrategy;
 
+  /// Tags used to group golden tests.
+  final List<String> tags;
+
   /// The theme data used to customize the appearance of widgets in the app.
   final ThemeData? theme;
 
@@ -80,6 +83,7 @@ class WidgetbookGoldenTestsProperties {
   /// * [errorImageUrl] – Placeholder URL for failed network images (defaults to `'error-network-image'`).
   /// * [loadingImageUrl] – Placeholder URL while loading network images (defaults to `'loading-network-image'`).
   /// * [precacheImagesTimeout] – Duration to wait for precaching images (defaults to `10 seconds`).
+  /// * [tags] – Tags used to group golden tests (defaults to `['golden']`).
   /// * [testGroupName] – Name of the golden test group (used for grouping tests) (defaults to `'Widgetbook golden tests'`).
   /// * [onTestError] - Function to be called when there is an error during the golden tests.
   /// * [networkImageResolver] - Custom function that resolves images from a given URI.
@@ -104,6 +108,7 @@ class WidgetbookGoldenTestsProperties {
     this.supportedLocales = const [Locale('en', 'US')],
     @Deprecated("Use 'skip' property in WidgetbookGoldenTestBuilder instead")
     this.skipTag = defaultSkipTag,
+    this.tags = const ['golden'],
     this.errorImageUrl = defaultErrorImageUrl,
     this.loadingImageUrl = defaultLoadingImageUrl,
     this.precacheImagesTimeout = const Duration(seconds: 10),
@@ -120,6 +125,7 @@ class WidgetbookGoldenTestsProperties {
     Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates,
     Iterable<Locale>? supportedLocales,
     String? skipTag,
+    List<String>? tags,
     String? errorImageUrl,
     String? loadingImageUrl,
     Duration? precacheImagesTimeout,
@@ -141,6 +147,7 @@ class WidgetbookGoldenTestsProperties {
       supportedLocales: supportedLocales ?? this.supportedLocales,
       // ignore: deprecated_member_use_from_same_package
       skipTag: skipTag ?? this.skipTag,
+      tags: tags ?? this.tags,
       errorImageUrl: errorImageUrl ?? this.errorImageUrl,
       loadingImageUrl: loadingImageUrl ?? this.loadingImageUrl,
       precacheImagesTimeout:

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_renderer_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_renderer_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widgetbook_golden_test_core/widgetbook_golden_test_core.dart';
+
+void main() {
+  group(WidgetbookGoldenRenderer.resolveTags, () {
+    test('returns properties.tags when goldenTestBuilder is null', () {
+      final properties = WidgetbookGoldenTestsProperties(
+        tags: ['custom-tag', 'another-tag'],
+      );
+
+      final result = WidgetbookGoldenRenderer.resolveTags(
+        goldenTestBuilder: null,
+        properties: properties,
+      );
+
+      expect(result, equals(['custom-tag', 'another-tag']));
+    });
+
+    test(
+      'returns default tags when properties has no custom tags and builder is null',
+      () {
+        final properties = WidgetbookGoldenTestsProperties();
+
+        final result = WidgetbookGoldenRenderer.resolveTags(
+          goldenTestBuilder: null,
+          properties: properties,
+        );
+
+        expect(result, equals(['golden']));
+      },
+    );
+
+    test('returns builder.tags when provided (overrides properties)', () {
+      final properties = WidgetbookGoldenTestsProperties(
+        tags: ['properties-tag'],
+      );
+      final builder = WidgetbookGoldenTestBuilder(
+        tags: ['builder-tag-1', 'builder-tag-2'],
+        builder: (_) => const SizedBox(),
+      );
+
+      final result = WidgetbookGoldenRenderer.resolveTags(
+        goldenTestBuilder: builder,
+        properties: properties,
+      );
+
+      expect(result, equals(['builder-tag-1', 'builder-tag-2']));
+    });
+
+    test(
+      'returns empty list when builder has empty tags (explicit override)',
+      () {
+        final properties = WidgetbookGoldenTestsProperties(
+          tags: ['properties-tag'],
+        );
+        final builder = WidgetbookGoldenTestBuilder(
+          tags: [],
+          builder: (_) => const SizedBox(),
+        );
+
+        final result = WidgetbookGoldenRenderer.resolveTags(
+          goldenTestBuilder: builder,
+          properties: properties,
+        );
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test('returns single tag when builder has a single tag', () {
+      final properties = WidgetbookGoldenTestsProperties(
+        tags: ['properties-tag-1', 'properties-tag-2'],
+      );
+      final builder = WidgetbookGoldenTestBuilder(
+        tags: ['single-builder-tag'],
+        builder: (_) => const SizedBox(),
+      );
+
+      final result = WidgetbookGoldenRenderer.resolveTags(
+        goldenTestBuilder: builder,
+        properties: properties,
+      );
+
+      expect(result, equals(['single-builder-tag']));
+    });
+  });
+}

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_builder_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_builder_test.dart
@@ -47,6 +47,7 @@ void main() {
         addonsMergeStrategy: strategy,
         goldenActions: actions,
         skip: true,
+        tags: ['custom-tag'],
         builder: _dummyBuilder,
       );
 
@@ -54,6 +55,31 @@ void main() {
       expect(builder.addonsMergeStrategy, equals(strategy));
       expect(builder.goldenActions, equals(actions));
       expect(builder.skip, isTrue);
+      expect(builder.tags, equals(['custom-tag']));
+    });
+
+    test('tags defaults to null', () {
+      final builder = WidgetbookGoldenTestBuilder(builder: _dummyBuilder);
+
+      expect(builder.tags, isNull);
+    });
+
+    test('can be created with custom tags list', () {
+      final builder = WidgetbookGoldenTestBuilder(
+        tags: ['smoke', 'ci', 'golden'],
+        builder: _dummyBuilder,
+      );
+
+      expect(builder.tags, equals(['smoke', 'ci', 'golden']));
+    });
+
+    test('can be created with empty tags list', () {
+      final builder = WidgetbookGoldenTestBuilder(
+        tags: [],
+        builder: _dummyBuilder,
+      );
+
+      expect(builder.tags, isEmpty);
     });
   });
 }

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_tests_properties_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_tests_properties_test.dart
@@ -136,4 +136,49 @@ void main() {
       expect(copied.precacheImagesTimeout, const Duration(minutes: 1));
     });
   });
+
+  group("tags", () {
+    test("defaults to ['golden']", () {
+      final properties = WidgetbookGoldenTestsProperties();
+
+      expect(properties.tags, equals(['golden']));
+    });
+
+    test("can be set with custom tags", () {
+      final properties = WidgetbookGoldenTestsProperties(
+        tags: ['custom-tag', 'another-tag'],
+      );
+
+      expect(properties.tags, equals(['custom-tag', 'another-tag']));
+    });
+
+    test("can be set with a single tag", () {
+      final properties = WidgetbookGoldenTestsProperties(tags: ['golden-ci']);
+
+      expect(properties.tags, equals(['golden-ci']));
+    });
+
+    test("copyWith preserves tags when not overridden", () {
+      final original = WidgetbookGoldenTestsProperties(
+        tags: ['custom-tag', 'another-tag'],
+      );
+      final copied = original.copyWith(testGroupName: "New name");
+
+      expect(copied.tags, equals(['custom-tag', 'another-tag']));
+    });
+
+    test("copyWith updates tags when provided", () {
+      final original = WidgetbookGoldenTestsProperties(tags: ['golden']);
+      final copied = original.copyWith(tags: ['ci', 'smoke']);
+
+      expect(copied.tags, equals(['ci', 'smoke']));
+    });
+
+    test("copyWith can override to empty list", () {
+      final original = WidgetbookGoldenTestsProperties(tags: ['golden']);
+      final copied = original.copyWith(tags: []);
+
+      expect(copied.tags, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Adds a new `tags` property to `WidgetbookGoldenTestsProperties`, allowing users to configure default tags for grouping golden tests (defaults to `['golden']`).
- Adds an optional `tags` parameter to `WidgetbookGoldenTestBuilder`, enabling per-test tag overrides that take precedence over the properties-level default.
- Introduces a static `resolveTags()` method on `WidgetbookGoldenRenderer` that resolves the effective tags for a golden test (builder tags override, then fall back to properties).
- Passes resolved tags into both Alchemist and Flutter Test renderers so they can be applied to individual tests.
- Adds `dart_test.yaml` with a `golden` tag to all three packages (`widgetbook_golden_test`, `widgetbook_golden_test_alchemist`, `widgetbook_golden_test_core`).

## Changes

### Added

- **`tags`** property on `WidgetbookGoldenTestsProperties` (defaults to `['golden']`).
- **`tags`** parameter on `WidgetbookGoldenTestBuilder` (defaults to `null`; when provided, overrides properties tags; empty list explicitly clears all tags).
- Static method **`WidgetbookGoldenRenderer.resolveTags()`** that resolves the effective tag list: builder tags take precedence over properties tags.
- **`dart_test.yaml`** files in each package with a `golden` tag definition.

### Unit tests

- **`widgetbook_golden_tests_properties_test.dart`**:
  - Default value is `['golden']`.
  - Custom tags can be set (single or multiple).
  - `copyWith` preserves the value when not overridden.
  - `copyWith` updates the value when provided.
  - `copyWith` can override to an empty list.

- **`widgetbook_golden_test_builder_test.dart`**:
  - `tags` defaults to `null`.
  - Can be created with a custom tags list.
  - Can be created with an empty tags list.

- **`widgetbook_golden_renderer_test.dart`** (new file):
  - Returns `properties.tags` when `goldenTestBuilder` is null.
  - Returns default `['golden']` when properties has no custom tags and builder is null.
  - Returns builder tags when provided (overrides properties).
  - Returns empty list when builder has an explicit empty tags list.
  - Handles single tag correctly.

### Changed

- **`WidgetbookGoldenTestBuilder`** now accepts an optional `tags` parameter for per-test tag overrides.
- **`WidgetbookGoldenRenderer`** now exposes a static `resolveTags()` method for tag resolution logic.
- **`WidgetbookGoldenFlutterTestRenderer`** passes resolved tags to `testWidgets()` via the `tags` parameter and forwards `properties` to `goldenTestZoneRunner()`.
- **`WidgetbookGoldenAlchemistRenderer`** passes resolved tags into both simple and action-based Alchemist golden tests.
