### PR TITLE
refactor: use runZonedGuarded to safely handle exceptions during widget pre-build execution

### DIFF
--- a/packages/widgetbook_golden_test_core/CHANGELOG.md
+++ b/packages/widgetbook_golden_test_core/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added [tags] property to [WidgetbookGoldenTestsProperties] to configure the tags for the golden tests. Also added a [tags] property to [WidgetbookGoldenTestBuilder] to configure the tags per use-case.
 
 ### Fixed
+- Use runZonedGuarded instead of simple try catch when trying to extract [WidgetbookGoldenTestBuilder] metadata. This solves an issue where no test were being executed when there was an error during the metadata extraction.
 
 ## 0.4.0
 Initial release.

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_generator.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_generator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -65,14 +67,20 @@ class WidgetbookGoldenTestGenerator {
   }) {
     WidgetbookGoldenTestBuilder? goldenTestBuilder;
     final mockContext = _BuildContextMock();
-    try {
-      final widget = useCase.build(mockContext);
-      if (widget is WidgetbookGoldenTestBuilder) {
-        goldenTestBuilder = widget;
-      }
-    } catch (e) {
-      // Not a WidgetbookGoldenTestBuilder.
-    }
+    // For some reason if we use try-catch here, an error will still propagate,
+    // causing tests to not execute without any message logs.
+    // With runZoneGuarded works as expected.
+    runZonedGuarded(
+      () {
+        final widget = useCase.build(mockContext);
+        if (widget is WidgetbookGoldenTestBuilder) {
+          goldenTestBuilder = widget;
+        }
+      },
+      (error, stack) {
+        // Not a WidgetbookGoldenTestBuilder. Ignore.
+      },
+    );
 
     // Skip the golden test case if it contains the [skip-golden] tag just as a fallback.
     bool shouldSkip =

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_generator_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_generator_test.dart
@@ -182,5 +182,33 @@ void main() {
         expect(executedGoldenCallback, true);
       });
     });
+
+    group('should not fail if metadata extraction fails', () {
+      bool executedMainTest = false;
+      final useCase = WidgetbookUseCase(
+        name: "Test use case",
+        builder: (context) => throw Exception("Test exception"),
+      );
+      final renderer = TestWidgetbookGoldenRenderer(
+        renderSimpleGoldenTestCallback:
+            (useCase, goldenPath, properties, skip, goldenTestBuilder) {
+              test('generated main test for use case', () async {
+                executedMainTest = true;
+                expect(goldenPath, ".");
+                expect(skip, false);
+                expect(useCase.name, "Test use case");
+              });
+            },
+      );
+
+      WidgetbookGoldenTestGenerator(
+        properties: WidgetbookGoldenTestsProperties(),
+        renderer: renderer,
+      ).generate(nodes: [useCase]);
+
+      tearDownAll(() {
+        expect(executedMainTest, true);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Replaces `try-catch` with `runZonedGuarded` when extracting `WidgetbookGoldenTestBuilder` metadata from use cases, preventing unhandled exceptions from silently blocking all test execution.

## Changes

### Added

- Unit tests for `WidgetbookGoldenTestGenerator`:
  - Verifies that golden tests still execute even when a use case's builder throws an exception during metadata extraction.

### Changed

- `WidgetbookGoldenTestGenerator._generate()` now wraps the use case build call in `runZonedGuarded` instead of `try-catch`. This prevents exceptions from propagating and silently preventing test execution.
- Updated `CHANGELOG.md` with the fix under the **Fixed** section.

### Why this change?

When using a plain `try-catch`, errors thrown during metadata extraction still propagate in certain Flutter testing contexts, causing all tests to be skipped without any diagnostic output. Using `runZonedGuarded` catches these exceptions at the zone level, allowing other valid test cases to continue executing normally.