### PR TITLE
feat: add skip property to GoldenPlayAction and decouple it from builder's skip flag

### DIFF
--- a/packages/widgetbook_golden_test_core/CHANGELOG.md
+++ b/packages/widgetbook_golden_test_core/CHANGELOG.md
@@ -3,9 +3,13 @@
 ### Added
 - Added [precacheImagesTimeout] property to [WidgetbookGoldenTestsProperties] to configure the timeout for precaching images.
 - Added [tags] property to [WidgetbookGoldenTestsProperties] to configure the tags for the golden tests. Also added a [tags] property to [WidgetbookGoldenTestBuilder] to configure the tags per use-case.
+- [GoldenPlayAction] now has a [skip] property to configure the skip per golden play action instead of relying on the [skip] property of [WidgetbookGoldenTestBuilder].
 
 ### Fixed
 - Use runZonedGuarded instead of simple try catch when trying to extract [WidgetbookGoldenTestBuilder] metadata. This solves an issue where no test were being executed when there was an error during the metadata extraction.
+
+### Changed
+- **Breaking Change**: Golden play actions no longer inherit the builder's skip flag by default, each action must set its own skip property if desired.
 
 ## 0.4.0
 Initial release.

--- a/packages/widgetbook_golden_test_core/lib/src/golden_play_action.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/golden_play_action.dart
@@ -25,6 +25,9 @@ class GoldenPlayAction {
   /// Optional finder callback to locate the widget for the golden snapshot.
   final WidgetFinderCallback? goldenFinder;
 
+  /// Optional flag to skip the golden action test.
+  final bool skip;
+
   /// Creates a [GoldenPlayAction].
   ///
   /// [name] is required and should describe the action.
@@ -34,5 +37,6 @@ class GoldenPlayAction {
     required this.name,
     required this.callback,
     this.goldenFinder,
+    this.skip = false,
   });
 }

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_builder.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_builder.dart
@@ -42,6 +42,7 @@ class WidgetbookGoldenTestBuilder extends StatelessWidget {
   final List<GoldenPlayAction>? goldenActions;
 
   /// Optional flag to skip the golden test.
+  /// This won't skip the golden play actions if they are not skipped by themselves.
   final bool skip;
 
   /// Optional list of tags to be applied to the golden test.

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_generator.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_test_generator.dart
@@ -104,7 +104,7 @@ class WidgetbookGoldenTestGenerator {
           properties: properties,
           useCase: useCase,
           action: play,
-          skip: shouldSkip,
+          skip: play.skip,
           goldenTestBuilder: goldenTestBuilder,
         );
       }

--- a/packages/widgetbook_golden_test_core/test/unit/golden_play_action_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/golden_play_action_test.dart
@@ -29,5 +29,41 @@ void main() {
       expect(action.callback, equals(callback));
       expect(action.goldenFinder, equals(goldenFinder));
     });
+
+    test('defaults skip to false', () async {
+      const name = 'Tap Action';
+      Future<void> callback(WidgetTester tester, CommonFinders find) async {}
+
+      var action = GoldenPlayAction(name: name, callback: callback);
+
+      expect(action.skip, isFalse);
+    });
+
+    test('initializes with skip set to true', () async {
+      const name = 'Skip Action';
+      Future<void> callback(WidgetTester tester, CommonFinders find) async {}
+
+      var action = GoldenPlayAction(name: name, callback: callback, skip: true);
+
+      expect(action.skip, isTrue);
+    });
+
+    test('initializes with all parameters including skip', () async {
+      const name = 'Complex Action';
+      Future<void> callback(WidgetTester tester, CommonFinders find) async {}
+      Finder goldenFinder(CommonFinders find) => find.text('Target');
+
+      var action = GoldenPlayAction(
+        name: name,
+        callback: callback,
+        goldenFinder: goldenFinder,
+        skip: true,
+      );
+
+      expect(action.name, equals(name));
+      expect(action.callback, equals(callback));
+      expect(action.goldenFinder, equals(goldenFinder));
+      expect(action.skip, isTrue);
+    });
   });
 }

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_generator_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_generator_test.dart
@@ -238,8 +238,9 @@ void main() {
       final renderer = TestWidgetbookGoldenRenderer(
         renderGoldenPlayActionTestCallback:
             (useCase, goldenPath, properties, action, skip, goldenTestBuilder) {
-              testWidgets('generated skipped golden play action test',
-                  (tester) async {
+              testWidgets('generated skipped golden play action test', (
+                tester,
+              ) async {
                 executed = true;
                 expect(goldenPath, ".");
                 expect(skip, true);
@@ -275,15 +276,17 @@ void main() {
       final renderer = TestWidgetbookGoldenRenderer(
         renderGoldenPlayActionTestCallback:
             (useCase, goldenPath, properties, action, skip, goldenTestBuilder) {
-              testWidgets('generated golden play action test with default skip',
-                  (tester) async {
-                executed = true;
-                expect(goldenPath, ".");
-                expect(skip, false);
-                expect(action.name, "action default skip");
-                expect(action.skip, false);
-                expect(useCase.name, "Test use case");
-              });
+              testWidgets(
+                'generated golden play action test with default skip',
+                (tester) async {
+                  executed = true;
+                  expect(goldenPath, ".");
+                  expect(skip, false);
+                  expect(action.name, "action default skip");
+                  expect(action.skip, false);
+                  expect(useCase.name, "Test use case");
+                },
+              );
             },
       );
 

--- a/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_generator_test.dart
+++ b/packages/widgetbook_golden_test_core/test/unit/widgetbook_golden_test_generator_test.dart
@@ -183,6 +183,118 @@ void main() {
       });
     });
 
+    group('should generate golden play action test with skip false', () {
+      bool executed = false;
+      final useCase = WidgetbookUseCase(
+        name: "Test use case",
+        builder: (context) => WidgetbookGoldenTestBuilder(
+          builder: (context) => Text("Hello world"),
+          goldenActions: [
+            GoldenPlayAction(
+              name: "action skip false",
+              callback: (_, _) async {},
+              skip: false,
+            ),
+          ],
+        ),
+      );
+      final renderer = TestWidgetbookGoldenRenderer(
+        renderGoldenPlayActionTestCallback:
+            (useCase, goldenPath, properties, action, skip, goldenTestBuilder) {
+              testWidgets('generated golden play action test', (tester) async {
+                executed = true;
+                expect(goldenPath, ".");
+                expect(skip, false);
+                expect(action.name, "action skip false");
+                expect(action.skip, false);
+                expect(useCase.name, "Test use case");
+              });
+            },
+      );
+
+      WidgetbookGoldenTestGenerator(
+        properties: WidgetbookGoldenTestsProperties(),
+        renderer: renderer,
+      ).generate(nodes: [useCase]);
+
+      tearDownAll(() => expect(executed, true));
+    });
+
+    group('should generate golden play action test with skip true', () {
+      bool executed = false;
+      final useCase = WidgetbookUseCase(
+        name: "Test use case",
+        builder: (context) => WidgetbookGoldenTestBuilder(
+          builder: (context) => Text("Hello world"),
+          goldenActions: [
+            GoldenPlayAction(
+              name: "action skip true",
+              callback: (_, _) async {},
+              skip: true,
+            ),
+          ],
+        ),
+      );
+      final renderer = TestWidgetbookGoldenRenderer(
+        renderGoldenPlayActionTestCallback:
+            (useCase, goldenPath, properties, action, skip, goldenTestBuilder) {
+              testWidgets('generated skipped golden play action test',
+                  (tester) async {
+                executed = true;
+                expect(goldenPath, ".");
+                expect(skip, true);
+                expect(action.name, "action skip true");
+                expect(action.skip, true);
+                expect(useCase.name, "Test use case");
+              });
+            },
+      );
+
+      WidgetbookGoldenTestGenerator(
+        properties: WidgetbookGoldenTestsProperties(),
+        renderer: renderer,
+      ).generate(nodes: [useCase]);
+
+      tearDownAll(() => expect(executed, true));
+    });
+
+    group('should generate golden play action test with default skip', () {
+      bool executed = false;
+      final useCase = WidgetbookUseCase(
+        name: "Test use case",
+        builder: (context) => WidgetbookGoldenTestBuilder(
+          builder: (context) => Text("Hello world"),
+          goldenActions: [
+            GoldenPlayAction(
+              name: "action default skip",
+              callback: (_, _) async {},
+            ),
+          ],
+        ),
+      );
+      final renderer = TestWidgetbookGoldenRenderer(
+        renderGoldenPlayActionTestCallback:
+            (useCase, goldenPath, properties, action, skip, goldenTestBuilder) {
+              testWidgets('generated golden play action test with default skip',
+                  (tester) async {
+                executed = true;
+                expect(goldenPath, ".");
+                expect(skip, false);
+                expect(action.name, "action default skip");
+                expect(action.skip, false);
+                expect(useCase.name, "Test use case");
+              });
+            },
+      );
+
+      WidgetbookGoldenTestGenerator(
+        properties: WidgetbookGoldenTestsProperties(),
+        renderer: renderer,
+      ).generate(nodes: [useCase]);
+
+      tearDownAll(() => expect(executed, true));
+    });
+
     group('should not fail if metadata extraction fails', () {
       bool executedMainTest = false;
       final useCase = WidgetbookUseCase(


### PR DESCRIPTION
## Summary

- Adds a new `skip` property to `GoldenPlayAction`, allowing users to configure whether an individual golden play action test should be skipped independently of the parent builder's skip flag.
- Decouples the skip behavior of golden play actions from `WidgetbookGoldenTestBuilder.skip`, so each action controls its own skip state.

## Changes

### Added

- **`skip`** property on `GoldenPlayAction` (defaults to `false`).
- Unit tests for `GoldenPlayAction`:
  - Defaults `skip` to `false`.
  - Can be initialized with `skip: true`.
  - Works correctly alongside all other parameters (`name`, `callback`, `goldenFinder`).
- Integration/unit tests for `WidgetbookGoldenTestGenerator`:
  - Generates golden play action test with `skip: false` (action runs).
  - Generates golden play action test with `skip: true` (action is skipped).
  - Uses default skip (`false`) when not explicitly provided.

### Changed

- **Breaking Change**: Golden play actions no longer inherit the builder's `skip` flag by default; each action must set its own `skip` property if skipping is desired.
- `WidgetbookGoldenTestGenerator` now passes `play.skip` instead of the inherited `shouldSkip` to the renderer when generating golden play action tests.
