### PR TITLE
refactor: name first parameter of onTestError in WidgetbookGoldenTestsProperties to error

### DIFF
--- a/packages/widgetbook_golden_test_core/CHANGELOG.md
+++ b/packages/widgetbook_golden_test_core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Use runZonedGuarded instead of simple try catch when trying to extract [WidgetbookGoldenTestBuilder] metadata. This solves an issue where no test were being executed when there was an error during the metadata extraction.
+- Named first parameter of [onTestError] in [WidgetbookGoldenTestsProperties] to be `error` instead of being unnamed.
 
 ### Changed
 - **Breaking Change**: Golden play actions no longer inherit the builder's skip flag by default, each action must set its own skip property if desired.

--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
@@ -61,7 +61,7 @@ class WidgetbookGoldenTestsProperties {
   /// Custom function that handles errors during golden tests.
   /// It has access to the original OnError function.
   final Function(
-    FlutterErrorDetails,
+    FlutterErrorDetails error,
     Function(FlutterErrorDetails)? originalOnError,
   )?
   onTestError;


### PR DESCRIPTION
## Summary

- Renames the first parameter of `onTestError` in `WidgetbookGoldenTestsProperties` from unnamed to `error`, improving API clarity and consistency with Dart conventions.

## Changes

### Changed

- **`WidgetbookGoldenTestsProperties.onTestError`**: The first parameter of the callback function is now explicitly named `error` (type `FlutterErrorDetails`) instead of being unnamed, making the code more readable and self-documenting.
