### PR TITLE
refactor: update onTestError callback signature to improve type readability

### DIFF
--- a/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
+++ b/packages/widgetbook_golden_test_core/lib/src/widgetbook_golden_tests_properties.dart
@@ -130,7 +130,11 @@ class WidgetbookGoldenTestsProperties {
     String? loadingImageUrl,
     Duration? precacheImagesTimeout,
     String? testGroupName,
-    Function(FlutterErrorDetails, Function(FlutterErrorDetails)?)? onTestError,
+    Function(
+      FlutterErrorDetails error,
+      Function(FlutterErrorDetails)? originalOnError,
+    )?
+    onTestError,
     NetworkImageResolver? networkImageResolver,
   }) {
     return WidgetbookGoldenTestsProperties(


### PR DESCRIPTION
Update the signature for copyWith as well to have a named error argument
This should have been part of https://github.com/lual98/widgetbook_golden_test/pull/40